### PR TITLE
added fallback if user just registered and has no courses

### DIFF
--- a/src/pages/dash/views/Default.jsx
+++ b/src/pages/dash/views/Default.jsx
@@ -14,8 +14,9 @@ class Default extends Component {
   async componentDidMount() {
     try {
       const { data } = await tyr.get('plague_doctor/dashboard');
+      console.log(data)
       /* eslint-disable-next-line */
-      this.setState(data);
+      this.setState({...data, courses: data.courses || []});
       console.log(data);
     } catch (e) {
       /* eslint-disable-next-line */


### PR DESCRIPTION
When I cloned and created a new user, dash would not render as the server yielded null and overwrites the initial state for courses (supposed to be []). This patch fixes this tiny issue. The PR is more to induce Rob's chagrin than to actually help your proj. I apologize sincerely.